### PR TITLE
Fix Vercel runtime config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "src/pages/**/*.ts": {
-      "runtime": "nodejs20.x"
+      "runtime": "@vercel/node@5.3.11"
     }
   }
 }


### PR DESCRIPTION
## Summary
- specify `@vercel/node` runtime with explicit version for all serverless pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896623ca06883239d225fa11137fd04