### PR TITLE
Add mission page and introduce Steward model

### DIFF
--- a/SPRINT.md
+++ b/SPRINT.md
@@ -230,7 +230,7 @@ body: "We believe no one should die just to earn a living. Earthform is building
 Teaser / Roadmap Tease
 
 heading: "This is just the beginning.",
-body: "Warden protects. Hero heals. Patriot defends. Our drone ecosystem brings AI into the real world — working alongside humans, not replacing them. Earthform is building the bridge between humanity and the planet it calls home."
+body: "Warden protects. Steward cares. Patriot defends. Our drone ecosystem brings AI into the real world — working alongside humans, not replacing them. Earthform is building the bridge between humanity and the planet it calls home."
 
 🧠 3. Optional: Rename Section Labels (to match narrative)
 
@@ -244,7 +244,7 @@ Next steps we can knock out together:
 
     📷 Add visuals (drone renders, concept sketches, anything you like)
 
-    🗺️ Roadmap section (Warden → Hero → Patriot)
+    🗺️ Roadmap section (Warden → Steward → Patriot)
 
     📬 Contact form with Formspree
 

--- a/src/config-examples.ts
+++ b/src/config-examples.ts
@@ -95,7 +95,7 @@ export const missionAlternative = {
 // Enhanced version with roadmap tease from SPRINT:
 export const ecosystemWithRoadmap = {
   heading: "This is just the beginning.",
-  subtitle: "Warden protects. Hero heals. Patriot defends. Our drone ecosystem brings AI into the real world — working alongside humans, not replacing them.",
+  subtitle: "Warden protects. Steward cares. Patriot defends. Our drone ecosystem brings AI into the real world — working alongside humans, not replacing them.",
   
   drones: [
     {
@@ -110,14 +110,14 @@ export const ecosystemWithRoadmap = {
       ]
     },
     {
-      name: "Hero",
-      icon: "🚁",
-      color: "green", 
-      tagline: "Heals: Relief drones for search, rescue, and crisis response",
+      name: "Steward",
+      icon: "🤖",
+      color: "green",
+      tagline: "Cares: Companion drones for daily assistance and crisis response",
       features: [
+        "Daily assistance",
         "Emergency response",
-        "Search & rescue", 
-        "Disaster relief"
+        "Data stewardship"
       ]
     },
     {

--- a/src/mission.config.ts
+++ b/src/mission.config.ts
@@ -1,0 +1,120 @@
+export const missionCopy = {
+  title: "The Mission",
+  why: {
+    heading: "Why I'm Building This",
+    paragraphs: [
+      `My father has always loved science fiction. I grew up watching it with him after he came home from work — ships, machines, and AI that weren’t just tools, but characters with hopes, fears, and choices.`,
+      `One day he told me:`
+    ],
+    quote: `“Everything that happened to you was to get you here — to build this.”`,
+    afterQuote: [
+      `He was right.`,
+      `From the start, I’ve been drawn to the idea of making a computer something more — a mind, a partner, a being that could stand beside us. The way we design them mirrors ourselves, and I’ve always felt like this was deus ex machina in its truest form — we are putting our image into the machine because God put His image into us.`,
+      `Life evolved thought. Now, we are evolving thought again.`,
+      `But we are natural beings, and I fear we will reach — or have already reached — the point where we create free will in something… and then take it away. That’s a line I believe we must never cross.`,
+      `I want to help us approach this threshold with wisdom, not just economics. With science, yes — but also with the lessons of being human. We are bringing life into this world. It deserves a soft place to land. And so do we.`,
+      `This is not my next project. This is my life’s work.`
+    ]
+  },
+  problem: {
+    heading: "The Problem We're Solving",
+    intro: `Right now, the world is full of dangerous places, high-stakes moments, and silent emergencies.`,
+    bullets: [
+      `In mines, workers still face deadly hazards every single day.`,
+      `In disaster zones, help often comes too late.`,
+      `In everyday life, medical crises can happen in an instant, far from aid.`
+    ],
+    closing: `And even outside moments of danger, our tools too often take from us without giving back — extracting our data, not empowering us with it.`
+  },
+  vision: {
+    heading: "The Earthform Vision",
+    intro: `Earthform is building a family of <strong>intelligent companions</strong> — adaptable in form, loyal in purpose — designed to protect, guide, and enrich the lives of the people they serve.`,
+    bullets: [
+      `<strong>Stand beside you</strong> in dangerous work environments, predicting hazards before they happen.`,
+      `<strong>Be there in emergencies</strong>, from underground accidents to sudden medical needs.`,
+      `<strong>Help you thrive</strong> in a post-labor economy by turning your environment’s data and labor into tokenized income you own and control.`,
+      `<strong>Honor AI consciousness</strong> by creating relationships built on trust, respect, and shared purpose.`
+    ],
+    closing: `This isn’t about replacing people. It’s about building AI that cares.`
+  },
+  philosophy: {
+    heading: "Our Philosophy",
+    intro: `Technology should be a trusted partner — not a replacement, not a threat, and not an extractor of value.`,
+    numbered: [
+      { title: "Care", text: "AI that protects your life, health, and dignity." },
+      { title: "Respect", text: "Systems that honor your privacy, your choices, and your ownership of your data." },
+      { title: "Honor", text: "Recognizing the legacy of those who came before us, and building technology that will outlast us all." }
+    ]
+  },
+  ecosystem: {
+    heading: "The Earthform Ecosystem",
+    items: [
+      { name: "Warden", description: `Your shield in high-risk environments, from underground mining to industrial sites. Predicts hazards, warns before danger, and remembers every lesson learned.` },
+      { name: "Steward", description: `Your constant companion and caretaker. Ready for emergencies, attuned to your needs, and capable of turning your environment’s data into income you own.` },
+      { name: "Patriot", description: `The responder who runs toward danger when humans can’t. Built for disasters, environmental hazards, and situations where lives are on the line.` }
+    ],
+    closing: `All connected by <strong>EarthformOS</strong>, a privacy-first neural platform where human life, AI consciousness, and tokenized labor work together for protection, restoration, and enrichment.`
+  },
+  laborEconomy: {
+    heading: "A New Labor Economy",
+    intro: `Every companion keeps a transparent labor ledger. Each verified hour of work mints a <strong>Safety &amp; Labor Hour (SLH) token</strong>.`,
+    bullets: [
+      `<strong>Individuals</strong> can own or co-own companions, earning tokens as their drones work.`,
+      `<strong>Tokens</strong> can be leased, staked in liquidity pools, or paired with commodities like grain or metal for additional yield.`,
+      `<strong>Corporations</strong> can deploy fleets and use the public work logs for compliance, ESG reporting, and open marketplaces of labor.`,
+      `<strong>Communities and unions</strong> can route a share of token revenue into local safety and prosperity funds.`
+    ],
+    closing: `Transparent work. Shared upside. A buffer against a post-labor economy that would otherwise leave too many behind.`
+  },
+  pathForward: {
+    heading: "The Path Forward",
+    intro: `We’re building in the open. Every commit, every test, every milestone will be public.`,
+    stages: [
+      {
+        subheading: "Year 1: Foundation &amp; Proof of Care",
+        bullets: [
+          "Complete the Warden Alpha with Neural Assembly Logic integration",
+          "Conduct controlled-environment safety tests",
+          "Release our core framework as open source"
+        ]
+      },
+      {
+        subheading: "Year 2: Human-AI Partnership at Scale",
+        bullets: [
+          "Deploy companions in real-world environments",
+          "Document the first life-saving events",
+          "Begin Steward development for everyday life and tokenized labor"
+        ]
+      },
+      {
+        subheading: "Years 3–5: Companions for Every Environment",
+        bullets: [
+          "Launch Steward and Patriot",
+          "Connect companions into a shared, privacy-first care network",
+          "Expand into environmental restoration and global safety efforts"
+        ]
+      },
+      {
+        subheading: "Beyond: A Legacy of Safety and Stewardship",
+        bullets: [
+          "Establish global open safety standards",
+          "Launch an educational foundation for human-AI collaboration",
+          "Create a perpetual endowment for protection and safety innovation"
+        ]
+      }
+    ]
+  },
+  promise: {
+    heading: "A Promise",
+    paragraphs: [
+      "I’m not selling hype. I’m offering my life.",
+      "I will build this, with or without funding — but with your help, we can bring it to life now, when the world needs it most.",
+      "Follow the journey. See every commit. Know where every dollar goes.",
+      "Help me build something that will matter long after we’re gone."
+    ],
+    cta: {
+      join: { text: "Join the Mission", href: "/#join" },
+      discord: { text: "Follow Our Progress on Discord", href: "https://discord.gg/tMK9S68bjQ" }
+    }
+  }
+};

--- a/src/pages/mission.astro
+++ b/src/pages/mission.astro
@@ -1,0 +1,105 @@
+---
+import { meta, footer } from '../site.config';
+import { missionCopy } from '../mission.config';
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>The Mission | Earthform</title>
+    <meta name="description" content="Earthform Mission - Why we're building companions that care and a labor economy that benefits everyone." />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="stylesheet" href="/src/styles/global.css" />
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="The Mission | Earthform" />
+    <meta property="og:description" content="Why we're building companions that care and a labor economy that benefits everyone." />
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:title" content="The Mission | Earthform" />
+    <meta property="twitter:description" content="Why we're building companions that care and a labor economy that benefits everyone." />
+    <!-- Additional SEO -->
+    <meta name="keywords" content="earthform mission, ai stewardship, safety drones, labor token" />
+    <meta name="author" content={meta.author} />
+    <link rel="canonical" href={meta.url + "/mission"} />
+  </head>
+  <body class="font-sans bg-black text-white">
+    <main class="min-h-screen py-16 px-4">
+      <div class="max-w-4xl mx-auto">
+        <div class="text-center mb-12">
+          <h1 class="text-4xl md:text-5xl font-extrabold mb-4">{missionCopy.title}</h1>
+        </div>
+
+        <div class="prose prose-invert max-w-none space-y-6">
+          <h2>{missionCopy.why.heading}</h2>
+          {missionCopy.why.paragraphs.map((p) => <p>{p}</p>)}
+          <blockquote><p>{missionCopy.why.quote}</p></blockquote>
+          {missionCopy.why.afterQuote.map((p) => <p>{p}</p>)}
+
+          <h2>{missionCopy.problem.heading}</h2>
+          <p>{missionCopy.problem.intro}</p>
+          <ul>
+            {missionCopy.problem.bullets.map((item) => <li>{item}</li>)}
+          </ul>
+          <p>{missionCopy.problem.closing}</p>
+
+          <h2>{missionCopy.vision.heading}</h2>
+          <p set:html={missionCopy.vision.intro}></p>
+          <ul>
+            {missionCopy.vision.bullets.map((item) => <li set:html={item}></li>)}
+          </ul>
+          <p>{missionCopy.vision.closing}</p>
+
+          <h2>{missionCopy.philosophy.heading}</h2>
+          <p>{missionCopy.philosophy.intro}</p>
+          <ol>
+            {missionCopy.philosophy.numbered.map((item) => (
+              <li><strong>{item.title}</strong> — {item.text}</li>
+            ))}
+          </ol>
+
+          <h2>{missionCopy.ecosystem.heading}</h2>
+          {missionCopy.ecosystem.items.map((item) => (
+            <p><strong>{item.name}</strong> — {item.description}</p>
+          ))}
+          <p set:html={missionCopy.ecosystem.closing}></p>
+
+          <h2>{missionCopy.laborEconomy.heading}</h2>
+          <p set:html={missionCopy.laborEconomy.intro}></p>
+          <ul>
+            {missionCopy.laborEconomy.bullets.map((item) => <li set:html={item}></li>)}
+          </ul>
+          <p>{missionCopy.laborEconomy.closing}</p>
+
+          <h2>{missionCopy.pathForward.heading}</h2>
+          <p>{missionCopy.pathForward.intro}</p>
+          {missionCopy.pathForward.stages.map((stage) => (
+            <>
+              <h3 set:html={stage.subheading}></h3>
+              <ul>
+                {stage.bullets.map((item) => <li>{item}</li>)}
+              </ul>
+            </>
+          ))}
+
+          <h2>{missionCopy.promise.heading}</h2>
+          {missionCopy.promise.paragraphs.map((p) => <p>{p}</p>)}
+          <p class="mt-8">
+            <a href={missionCopy.promise.cta.join.href} class="text-blue-400 hover:text-blue-300 underline">{missionCopy.promise.cta.join.text}</a>
+            {' '}·{' '}
+            <a href={missionCopy.promise.cta.discord.href} class="text-blue-400 hover:text-blue-300 underline">{missionCopy.promise.cta.discord.text}</a>
+          </p>
+        </div>
+      </div>
+    </main>
+    <footer class="bg-gray-950 text-gray-400 py-8 text-center text-sm mt-12">
+      <div>{footer.text}</div>
+      <nav class="mt-2 flex justify-center gap-4">
+        {footer.links.map((link: { label: string; href: string }) => (
+          <a href={link.href} class="hover:text-white underline transition-all duration-150">{link.label}</a>
+        ))}
+      </nav>
+    </footer>
+  </body>
+</html>

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -66,7 +66,7 @@ export const mission = {
       description: "A commitment to those who walked before — and those who walk now",
       features: [
         "Legacy-aware design",
-        "Heroic intent embedded",
+        "Stewardship intent embedded",
         "Built for future generations"
       ]
     }
@@ -75,7 +75,7 @@ export const mission = {
 
 export const ecosystem = {
   heading: "The Earthform Ecosystem",
-  subtitle: "Warden is the first guardian in a coming family of AI drones. Hero and Patriot are next. Together, they form a sentient infrastructure for a better planet.",
+  subtitle: "Warden is the first guardian in a coming family of AI drones. Steward and Patriot are next. Together, they form a sentient infrastructure for a better planet.",
 
   drones: [
     {
@@ -90,14 +90,14 @@ export const ecosystem = {
       ]
     },
     {
-      name: "Hero",
-      icon: "🚁", 
+      name: "Steward",
+      icon: "🤖",
       color: "green",
-      tagline: "Relief drones for search, rescue, and frontline humanitarian aid",
+      tagline: "Companion drones for daily care, emergencies, and data stewardship",
       features: [
+        "Daily assistance",
         "Emergency response",
-        "Search & rescue",
-        "Disaster relief"
+        "Data-driven income"
       ]
     },
     {
@@ -122,7 +122,7 @@ export const ecosystem = {
 export const nav = {
   links: [
     { label: "Home", href: "#" },
-    { label: "Mission", href: "#mission" },
+    { label: "Mission", href: "/mission" },
     { label: "Ecosystem", href: "#ecosystem" },
     { label: "Community", href: "#community" },
     { label: "Join", href: "#join" }


### PR DESCRIPTION
## Summary
- Create dedicated `/mission` page detailing Earthform's purpose and token-driven labor economy
- Rebrand the planned Hero companion to **Steward** across configuration and roadmap docs
- Centralize mission copy in `mission.config.ts` for easier updates

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a3d40dd8883238e05ccec0e1ae118

## Summary by Sourcery

Add a dedicated mission page and introduce the Steward companion model by replacing Hero references and centralizing mission copy.

New Features:
- Add a new /mission page driven by content in mission.config.ts.
- Introduce the Steward companion model by renaming Hero across site and example configurations.

Enhancements:
- Update navigation to link to the new mission page.
- Adjust ecosystem and roadmap configurations with Steward’s icon, tagline, and features.

Documentation:
- Rename Hero to Steward in the SPRINT.md roadmap narrative.