### PR TITLE
Fix scroll gaps for landing page scrollytelling

### DIFF
--- a/src/components/ScrolltellingMissionSection.tsx
+++ b/src/components/ScrolltellingMissionSection.tsx
@@ -164,7 +164,7 @@ export const ScrolltellingMissionSection: React.FC<ScrolltellingMissionSectionPr
   }, [stories.length]);
 
   return (
-    <section className="relative bg-gradient-to-br from-black via-gray-900 to-black min-h-screen py-20">
+    <section className="relative bg-gradient-to-br from-black via-gray-900 to-black h-full py-20">
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-5">
         <motion.div

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -23,7 +23,8 @@ body {
 .scroll-snap-section {
   scroll-snap-align: start;
   scroll-snap-stop: normal;
-  min-height: 100vh; /* Ensure sections fill viewport */
+  height: 100vh; /* Ensure sections fill viewport without extra space */
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -44,9 +45,9 @@ body {
   body {
     scroll-snap-type: none;
   }
-  
+
   .scroll-snap-section {
-    min-height: auto;
+    height: auto;
     padding: 2rem 0;
   }
 }


### PR DESCRIPTION
## Summary
- prevent extra spacing by forcing snap sections to use `height:100vh`
- align scroll telling section with parent height

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a66f7e27c8323ae6a6bec35a5428b